### PR TITLE
fix: build local Dockerfile in its directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,8 +507,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tar",
- "tempfile",
  "tokio",
  "toml",
  "which 6.0.3",
@@ -915,18 +913,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "filetime"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "fnv"
@@ -1675,17 +1661,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
-dependencies = [
- "bitflags",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,15 +2039,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -2639,17 +2605,6 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "tar"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
 ]
 
 [[package]]
@@ -3457,16 +3412,6 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
-
-[[package]]
-name = "xattr"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
-dependencies = [
- "libc",
- "rustix 1.0.8",
-]
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,11 @@ clap = { version = "4.5", features = ["derive"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tempfile = "3.10"
 which = "6.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 toml = "0.8"
 openssl = { version = "0.10", features = ["vendored"] }
-
-# 新增：AWS SDK + Docker API + async 依赖
+# Additional AWS SDK, Docker API and async dependencies
 aws-config = "1.5"
 aws-sdk-sts = "1.28"
 aws-sdk-ecr = "1.38"
@@ -31,7 +29,6 @@ bytes = "1.6"
 bollard = "0.17"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs", "time"] }
 futures = "0.3"
-tar = "0.4"
 log = "0.4"
 env_logger = "0.11"
 xshell = "0.2"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A CLI to create e2b templates and push base images to AWS ECR for self-hosted e2
 ## Features
 - Create templates via e2b API
 - Build or select base images (Dockerfile, ECR image, or default image)
+- When building a local Dockerfile, run `docker build` in the Dockerfile directory to ensure `COPY` instructions can access files
 - Push base images to AWS ECR
 - Report build completion and poll build status
 


### PR DESCRIPTION
## Summary
- Build temporary images directly in the Dockerfile directory so `COPY` instructions succeed
- Remove temporary directory and tar build logic, simplifying dependencies
- Document that local builds run in the Dockerfile's directory
- Translate comments and README to English

## Testing
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ec4b437083289bc1845ec1a06225