### PR TITLE
限制 Docker 构建为 amd64 平台

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A CLI to create e2b templates and push base images to AWS ECR for self-hosted e2
 - Create templates via e2b API
 - Build or select base images (Dockerfile, ECR image, or default image)
 - When building a local Dockerfile, run `docker build` in its directory so `COPY` instructions can access files
+- By default, `docker build` uses `--platform linux/amd64` to restrict the target architecture
 - Push base images to AWS ECR
 - Report build completion and poll build status
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -593,9 +593,10 @@ async fn build_temp_image(dockerfile_path: &Path) -> Result<String> {
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
+    // e2b currently does not support ARM images, so enforce linux/amd64 platform during build
     cmd!(
         sh,
-        "docker build -t {tag} -f {dockerfile_path} {context_dir}"
+        "docker build --platform linux/amd64 -t {tag} -f {dockerfile_path} {context_dir}"
     )
     .run()?;
     Ok(tag)


### PR DESCRIPTION
## Summary
- `docker build` 默认使用 `--platform linux/amd64`
- 注释改为英文，说明 e2b 仅支持非 ARM 架构

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build`
- `cargo test --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68a56c656cdc83288bbdcc94a5ff88cf