### PR TITLE
更新 AGENTS.md 使用英文描述贡献规范

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS
+
+This repository maintains the `aws_e2b` CLI, which helps users interact with e2b that is self-hosted on AWS.
+
+## Contribution Guidelines
+
+- All documentation and code comments must be written in English with clear wording. Do not use abbreviations.
+- Variable and function names should be explicit and avoid shorthand.
+- Follow Rust community best practices for code style.
+- Before committing, run the following commands to stay consistent with GitHub CI:
+  - `cargo fmt --all -- --check`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo test`
+- All commits must pass GitHub CI.
+- Update related documentation with every code change.


### PR DESCRIPTION
## Summary
- 重写 AGENTS.md 为英文描述
- 说明 aws_e2b CLI 用于与自托管的 e2b 交互并约定英文注释

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(编译耗时过长，中途终止)*

------
https://chatgpt.com/codex/tasks/task_e_68a6869697e08328a72c7b17bb195584