### PR TITLE
代理未实现子命令并更新文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ Or use an existing ECR image:
 aws_e2b template build --config ./aws_e2b.toml --ecr-image 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-image:tag
 ```
 
+## Proxy other commands
+`aws_e2b` only implements `template build` internally. All other subcommands are forwarded to the official `e2b` CLI.
+During forwarding, the `E2B_DOMAIN` and `E2B_ACCESS_TOKEN` environment variables are set automatically if they exist in the environment or user configuration.
+Example:
+```bash
+aws_e2b template list  # equivalent to e2b template list
+```
+The `auth` subcommand is not supported and will not be proxied.
+
 ## Configuration
 - Template configuration file: `aws_e2b.toml`
 - User configuration: `~/.aws_e2b/config.toml`


### PR DESCRIPTION
## 摘要
- 将 README 中的代理说明改为英文，并明确 `auth` 子命令不可用
- 还原主程序中被翻译成中文的注释和错误信息

## 测试
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a698ed5ab48328950d82fa83d7c490