### PR TITLE
feat: support template listing and team configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ aws_region = "us-east-1"
 [e2b]
 e2b_domain = "e2b.dev"
 e2b_access_token = "YOUR_TOKEN" # or set environment variable E2B_ACCESS_TOKEN
+e2b_api_key = "YOUR_API_KEY"    # or set environment variable E2B_API_KEY
 e2b_team_id = "YOUR_TEAM_ID"    # overridden by the --team argument
 ```
 
@@ -89,6 +90,7 @@ e2b_team_id = "YOUR_TEAM_ID"    # overridden by the --team argument
 - AWS region: environment variable `AWS_REGION` > user config `[aws].aws_region`
 - e2b domain: environment variable `E2B_DOMAIN` > user config `[e2b].e2b_domain`
 - access token: environment variable `E2B_ACCESS_TOKEN` > user config `[e2b].e2b_access_token`
+- API key: environment variable `E2B_API_KEY` > user config `[e2b].e2b_api_key`
 - team identifier: `--team` > user config `[e2b].e2b_team_id`
 
 ## License

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ cargo install --git https://github.com/seedleap/aws_e2b
 ```
 
 ## Usage examples
+Run `aws_e2b --help` to view all available commands and options.
+
 Build a template:
 ```bash
 aws_e2b template build \

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # aws_e2b
 
-A command-line tool for building e2b templates and pushing base images to Amazon Elastic Container Registry (ECR).
+Command-line tool for interacting with e2b templates and sandboxes in a self-hosted AWS environment.
 
 ## Features
-- Build templates through the e2b application programming interface.
+- Build templates through the e2b API.
 - Use a local Dockerfile, an existing ECR image, or a default image as the base.
-- When a local Dockerfile is provided, `docker build` runs in its directory so `COPY` instructions can access local files.
+- When a Dockerfile is provided, `docker build` runs in its directory so `COPY` instructions can access local files.
 - `docker build` runs with `--platform linux/amd64` to ensure x86 compatibility.
 - Push the base image to Amazon ECR.
-- Notify the API after the image is pushed and poll for the build status.
+- Notify the e2b API and poll for the build status.
 
 ## Installation
 From source:
@@ -21,7 +21,8 @@ From Git:
 cargo install --git https://github.com/seedleap/aws_e2b
 ```
 
-## Usage example
+## Usage examples
+Build a template:
 ```bash
 aws_e2b template build \
   --config ./aws_e2b.toml \
@@ -38,12 +39,16 @@ Use an existing ECR image:
 aws_e2b template build --config ./aws_e2b.toml --ecr-image 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-image:tag
 ```
 
-## Forwarding other commands
-`aws_e2b` implements only `template build`. All other subcommands are forwarded to the official `e2b` command-line interface. During forwarding, `E2B_DOMAIN` and `E2B_ACCESS_TOKEN` are set automatically if they exist in environment variables or user configuration.
+List templates for a team:
 ```bash
-aws_e2b template list  # Equivalent to e2b template list
+aws_e2b template list --team YOUR_TEAM_ID
 ```
-The `auth` subcommand is not supported and will not be forwarded.
+If `--team` is omitted, the team identifier is read from `[e2b].e2b_team_id` in `~/.aws_e2b/config.toml`.
+
+## Command forwarding rules
+- `template build` and `template list` are implemented by this tool.
+- `sandbox` subcommands are forwarded to the official `e2b` CLI.
+- All other commands are unsupported.
 
 ## Configuration files
 - Template configuration: `aws_e2b.toml`
@@ -57,12 +62,12 @@ cpu_count = 4
 # start_cmd = "/root/.jupyter/start-up.sh"
 # ready_cmd = "curl -sf http://127.0.0.1:8888/health"
 # alias = "ci-python"
-# template_id = "j4iitty8yuz06tfnm5du" # Build using an existing template ID
+# template_id = "j4iitty8yuz06tfnm5du" # build using an existing template ID
 
 [docker]
 # dockerfile = "./Dockerfile"
 # ecr-image = "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-image:tag"
-# dockerimage = "e2bdev/code-interpreter:latest"
+# base-image = "e2bdev/code-interpreter:latest"
 ```
 
 User configuration `~/.aws_e2b/config.toml`:
@@ -73,20 +78,22 @@ aws_region = "us-east-1"
 [e2b]
 e2b_domain = "e2b.dev"
 e2b_access_token = "YOUR_TOKEN" # or set environment variable E2B_ACCESS_TOKEN
+e2b_team_id = "YOUR_TEAM_ID"    # overridden by the --team argument
 ```
 
-## Argument priority
-- Memory, CPU, start command, ready command, alias: command line > `aws_e2b.toml` > defaults
-- template_id: command line > `aws_e2b.toml` > create new template
-- AWS region: environment variable `AWS_REGION` > `~/.aws_e2b/config.toml` `[aws].aws_region`
-- e2b domain: environment variable `E2B_DOMAIN` > `~/.aws_e2b/config.toml` `[e2b].e2b_domain`
-- Access token: environment variable `E2B_ACCESS_TOKEN` > `~/.aws_e2b/config.toml` `[e2b].e2b_access_token`
+## Parameter precedence
+- Memory, CPU, `start_cmd`, `ready_cmd`, `alias`: CLI > `aws_e2b.toml` > default value
+- `template_id`: CLI > `aws_e2b.toml` > create new template
+- AWS region: environment variable `AWS_REGION` > user config `[aws].aws_region`
+- e2b domain: environment variable `E2B_DOMAIN` > user config `[e2b].e2b_domain`
+- access token: environment variable `E2B_ACCESS_TOKEN` > user config `[e2b].e2b_access_token`
+- team identifier: `--team` > user config `[e2b].e2b_team_id`
 
 ## License
 MIT or Apache-2.0
 
 ## Development
-GitHub Actions runs formatting, Clippy, build, and tests. To reproduce locally:
+GitHub Actions runs format checks, Clippy, build, and tests. Reproduce locally:
 ```bash
 rustup component add clippy rustfmt
 cargo fmt --all -- --check

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
 
 /// All arguments for the `template build` subcommand
@@ -65,4 +65,52 @@ pub struct ListArgs {
     /// Team identifier to query; if omitted it is loaded from the configuration file
     #[arg(long = "team")]
     pub team: Option<String>,
+}
+
+/// Top-level command-line parser for aws_e2b
+#[derive(Parser, Debug)]
+#[command(
+    name = "aws_e2b",
+    about = "AWS wrapper for e2b templates and sandboxes"
+)]
+pub struct AwsE2bCli {
+    /// Supported subcommands for aws_e2b
+    #[command(subcommand)]
+    pub command: AwsE2bCommand,
+}
+
+/// Subcommands available in aws_e2b
+#[derive(Subcommand, Debug)]
+pub enum AwsE2bCommand {
+    /// Manage templates
+    Template {
+        /// Operations related to templates
+        #[command(subcommand)]
+        command: TemplateCommand,
+    },
+    /// Forward sandbox subcommands to the official e2b CLI
+    Sandbox(SandboxArgs),
+}
+
+/// Template-related subcommands
+#[derive(Subcommand, Debug)]
+pub enum TemplateCommand {
+    /// Build a template
+    Build(BuildArgs),
+    /// List templates for a team
+    List(ListArgs),
+}
+
+/// Capture arguments after the `sandbox` subcommand for forwarding
+#[derive(Args, Debug)]
+#[command(
+    about = "Forward sandbox commands to the official e2b CLI",
+    trailing_var_arg = true,
+    allow_hyphen_values = true,
+    disable_help_flag = true
+)]
+pub struct SandboxArgs {
+    /// Arguments to forward after `sandbox`
+    #[arg(required = true)]
+    pub args: Vec<String>,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -58,3 +58,11 @@ pub struct DockerArgs {
     #[arg(long = "base-image", help_heading = "DOCKER")]
     pub base_image: Option<String>,
 }
+
+/// Arguments for the `template list` subcommand
+#[derive(Parser, Debug)]
+pub struct ListArgs {
+    /// Team identifier to query; if omitted it is loaded from the configuration file
+    #[arg(long = "team")]
+    pub team: Option<String>,
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,9 @@ pub struct UserE2bSection {
     pub e2b_domain: Option<String>,
     #[serde(default, rename = "e2b_access_token")]
     pub e2b_access_token: Option<String>,
+    /// e2b team identifier for the user
+    #[serde(default, rename = "e2b_team_id")]
+    pub e2b_team_id: Option<String>,
 }
 
 /// Load `aws_e2b.toml` and return the configuration and its directory

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,9 @@ pub struct UserE2bSection {
     pub e2b_domain: Option<String>,
     #[serde(default, rename = "e2b_access_token")]
     pub e2b_access_token: Option<String>,
+    /// e2b API key for the user
+    #[serde(default, rename = "e2b_api_key")]
+    pub e2b_api_key: Option<String>,
     /// e2b team identifier for the user
     #[serde(default, rename = "e2b_team_id")]
     pub e2b_team_id: Option<String>,


### PR DESCRIPTION
## Summary
- Support reading e2b team identifier from user config
- Add `template list` command and forward to official CLI
- Restrict supported commands to `template build`, `template list`, and forwarding `sandbox` subcommands
- Document and comments reverted to English

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a740147a388328a543f4b378715b0e