### PR TITLE
Check for e2b CLI before proxying commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ If `--team` is omitted, the team identifier is read from `[e2b].e2b_team_id` in 
 ## Command forwarding rules
 - `template build` and `template list` are implemented by this tool.
 - `sandbox` subcommands are forwarded to the official `e2b` CLI.
+- `aws_e2b` verifies that the official `e2b` CLI is installed and instructs installation from <https://e2b.dev/docs/cli> when it is missing.
 - All other commands are unsupported.
 
 ## Configuration files

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use std::env;
+use which::which;
 
 mod args;
 mod aws_utils;
@@ -50,6 +51,13 @@ async fn main() -> Result<()> {
 
 /// Forward a command to the official e2b CLI and inject domain, access token, and API key environment variables
 fn proxy_to_e2b(args: &[String]) -> Result<()> {
+    // Ensure the official e2b CLI is installed before forwarding the command.
+    if which("e2b").is_err() {
+        return Err(anyhow!(
+            "The e2b CLI was not found. Please install it by following https://e2b.dev/docs/cli"
+        ));
+    }
+
     let (domain_opt, token_opt, api_key_opt) = resolve_e2b_env_vars();
 
     let mut command = std::process::Command::new("e2b");


### PR DESCRIPTION
## Summary
- ensure `aws_e2b` checks for the official `e2b` CLI before forwarding commands
- document the requirement to install the `e2b` CLI when missing

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: hangs compiling dependencies)*
- `cargo test` *(fails: hangs compiling dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68b11384862883288d71b0de364b7cf8