### PR TITLE
Fail build when status not ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Command-line tool for interacting with e2b templates and sandboxes in a self-hos
 - `docker build` runs with `--platform linux/amd64` to ensure x86 compatibility.
 - Push the base image to Amazon ECR.
 - Notify the e2b API and poll for the build status.
+- The command exits with an error if the final status is not ready.
 
 ## Installation
 From source:


### PR DESCRIPTION
## Summary
- ensure template build errors when final status is not `ready`
- document build failure behaviour

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b6bc76f62c832883a147f03280b3b7